### PR TITLE
Replace public NodeIndex with generic NodeId

### DIFF
--- a/crates/fracture/src/lib.rs
+++ b/crates/fracture/src/lib.rs
@@ -3,7 +3,7 @@ mod base;
 use common::modular_decomposition::MDNodeKind;
 use modular_decomposition::fracture::modular_decomposition as fracture_modular_decomposition;
 use modular_decomposition::ModuleKind;
-use petgraph::graph::{DiGraph, UnGraph};
+use petgraph::graph::{DiGraph, NodeIndex, UnGraph};
 use tracing::info;
 
 #[macro_export]
@@ -28,7 +28,7 @@ pub fn prepare<N, E>(graph: &UnGraph<N, E>) -> Prepared {
 }
 
 pub struct Computed {
-    tree: DiGraph<ModuleKind, ()>,
+    tree: DiGraph<ModuleKind<NodeIndex>, ()>,
 }
 
 impl Prepared {

--- a/crates/modular-decomposition/examples/adj_vector_graph.rs
+++ b/crates/modular-decomposition/examples/adj_vector_graph.rs
@@ -82,6 +82,6 @@ fn main() {
             factorizing_permutation.push(u);
         }
     }
-    let factorizing_permutation: Vec<_> = factorizing_permutation.iter().map(|u| u.index()).collect();
+    let factorizing_permutation: Vec<_> = factorizing_permutation.to_vec();
     println!("{:?}", factorizing_permutation);
 }

--- a/crates/modular-decomposition/src/lib.rs
+++ b/crates/modular-decomposition/src/lib.rs
@@ -69,13 +69,15 @@ mod tests;
 
 pub use fracture::modular_decomposition;
 pub use md_tree::MDTree;
-pub use md_tree::ModuleKind;
 pub use md_tree::ModuleIndex;
+pub use md_tree::ModuleKind;
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::md_tree::{MDTree, ModuleKind, NodeIndex};
+    use crate::md_tree::{MDTree, ModuleKind};
+    use petgraph::graph::NodeIndex;
+    use petgraph::visit::NodeIndexable;
 
     #[derive(Default, Debug)]
     struct ModuleKindCounts {
@@ -91,7 +93,7 @@ mod test {
         }
     }
 
-    fn count_module_kinds(md: &MDTree) -> ModuleKindCounts {
+    fn count_module_kinds(md: &MDTree<NodeIndex>) -> ModuleKindCounts {
         let mut counts = ModuleKindCounts::default();
         for kind in md.module_kinds() {
             match kind {
@@ -117,7 +119,7 @@ mod test {
         let md = modular_decomposition(&graph).unwrap();
         assert_eq!(md.node_count(), 1);
         assert_eq!(count_module_kinds(&md), [0, 0, 0, 1]);
-        assert_eq!(md.module_kind(md.root()), Some(&ModuleKind::Node(NodeIndex::new(0))));
+        assert_eq!(md.module_kind(md.root()), Some(&ModuleKind::Node(graph.from_index(0))));
     }
 
     #[test]

--- a/crates/modular-decomposition/src/md_tree.rs
+++ b/crates/modular-decomposition/src/md_tree.rs
@@ -26,7 +26,7 @@ pub enum ModuleKind<NodeId: Copy + PartialEq> {
     Node(NodeId),
 }
 
-impl<Ix: Debug + Copy + PartialEq> Debug for ModuleKind<Ix> {
+impl<NodeId: Debug + Copy + PartialEq> Debug for ModuleKind<NodeId> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             ModuleKind::Prime => {

--- a/crates/modular-decomposition/src/md_tree.rs
+++ b/crates/modular-decomposition/src/md_tree.rs
@@ -134,3 +134,31 @@ impl Display for NullGraphError {
 }
 
 impl std::error::Error for NullGraphError {}
+
+#[cfg(test)]
+mod test {
+    use petgraph::graph::NodeIndex;
+    use petgraph::Outgoing;
+
+    use crate::tests::complete_graph;
+    use crate::{modular_decomposition, ModuleKind};
+
+    #[test]
+    fn mdtree_and_digraph_are_equivalent() {
+        let graph = complete_graph(5);
+        let md = modular_decomposition(&graph).unwrap();
+        let root = md.root();
+
+        assert_eq!(md.module_kind(root), Some(&ModuleKind::Series));
+
+        let children: Vec<_> = md.children(root).collect();
+        assert_eq!(md.module_kind(children[0]), Some(&ModuleKind::Node(NodeIndex::new(0))));
+
+        let md = md.into_digraph();
+        let root = NodeIndex::new(root.index());
+
+        let children: Vec<_> = md.neighbors_directed(root, Outgoing).collect();
+        assert_eq!(md.node_weight(root), Some(&ModuleKind::Series));
+        assert_eq!(md.node_weight(children[0]), Some(&ModuleKind::Node(NodeIndex::new(0))));
+    }
+}


### PR DESCRIPTION
This removes the md_tree::NodeIndex from the public API and makes ModuleKind generic.